### PR TITLE
Added checks for shop existence in `ongr:sync:storage:create` and if no `shop-id` is provided storage for active shop is created.

### DIFF
--- a/DependencyInjection/ONGRConnectionsExtension.php
+++ b/DependencyInjection/ONGRConnectionsExtension.php
@@ -116,10 +116,11 @@ class ONGRConnectionsExtension extends Extension
             ]
         );
 
+        $definition->addMethodCall('setContainer', [new Reference('service_container')]);
+
         // Initiate SyncStorage and inject storage manager into it.
-        $definition = $container->getDefinition('ongr_connections.sync.sync_storage');
-        $definition->setArguments(
-            [$container->getDefinition('ongr_connections.sync.storage_manager.mysql_storage_manager')]
+        $container->getDefinition('ongr_connections.sync.sync_storage')->setArguments(
+            [$definition]
         );
     }
 }

--- a/Tests/Functional/Command/SyncStorageCreateCommandTest.php
+++ b/Tests/Functional/Command/SyncStorageCreateCommandTest.php
@@ -43,7 +43,7 @@ class SyncStorageCreateCommandTest extends AbstractTestCase
      */
     public function testExecuteWithShopId()
     {
-        $testShopId = 14;
+        $testShopId = 12345;
 
         $commandTester = new CommandTester($this->executeCommand);
         $commandTester->execute(
@@ -77,7 +77,7 @@ class SyncStorageCreateCommandTest extends AbstractTestCase
      */
     public function testExecuteWithoutShopId()
     {
-        $defaultStorage = 'ongr_sync_storage';
+        $defaultStorage = 'ongr_sync_storage_0';
 
         $commandTester = new CommandTester($this->executeCommand);
         $commandTester->execute(

--- a/Tests/Functional/Fixtures/SyncStorage/storageWithoutShop.sql
+++ b/Tests/Functional/Fixtures/SyncStorage/storageWithoutShop.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `ongr_sync_storage` (
+CREATE TABLE `ongr_sync_storage_0` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `type` varchar(1) COLLATE utf8_unicode_ci NOT NULL COMMENT 'C-CREATE(INSERT),U-UPDATE,D-DELETE',
   `document_type` varchar(32) COLLATE utf8_unicode_ci NOT NULL,

--- a/Tests/Functional/Fixtures/SyncStorage/tableSingle_shop12345.sql
+++ b/Tests/Functional/Fixtures/SyncStorage/tableSingle_shop12345.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `ongr_sync_storage_14` (
+CREATE TABLE `ongr_sync_storage_12345` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `type` varchar(1) COLLATE utf8_unicode_ci NOT NULL COMMENT 'C-CREATE(INSERT),U-UPDATE,D-DELETE',
   `document_type` varchar(32) COLLATE utf8_unicode_ci NOT NULL,

--- a/Tests/Functional/Sync/Extractor/PassthroughExtractorTest.php
+++ b/Tests/Functional/Sync/Extractor/PassthroughExtractorTest.php
@@ -53,6 +53,8 @@ class PassthroughExtractorTest extends AbstractTestCase
         parent::setUp();
 
         $this->storageManager = new MysqlStorageManager($this->getConnection(), self::TABLE_NAME);
+        $this->storageManager->setContainer($this->getServiceContainer());
+
         $this->syncStorage = new SyncStorage($this->storageManager);
 
         $this->extractor = new PassthroughExtractor();

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -76,3 +76,12 @@ ongr_elasticsearch:
             connection: bar
             mappings:
                 - ONGRElasticsearchBundle
+
+ongr_connections:
+    shops:
+        default:
+            shop_id: 0
+        other:
+            shop_id: 1
+        shop_12345:
+            shop_id: 12345


### PR DESCRIPTION
closes #116.