### PR TITLE
Higher ongr:import:full ProgressBar redraw frequency makes cleaner output logs.

### DIFF
--- a/Pipeline/Pipeline.php
+++ b/Pipeline/Pipeline.php
@@ -73,7 +73,10 @@ class Pipeline implements PipelineInterface
         );
         $this->setContext($startEvent->getContext());
 
-        $this->progressBar && $this->progressBar->start($this->countSourceItems($sources));
+        $count = $this->countSourceItems($sources);
+
+        $this->progressBar && $this->progressBar->setRedrawFrequency($count > 10 ? $count / 10 : 1);
+        $this->progressBar && $this->progressBar->start($count);
 
         foreach ($sources as $source) {
             foreach ($source as $item) {


### PR DESCRIPTION
Currently the ongr:import:full command fill up the output log in a dirty way like this:
```
 DEBUG [3b4d13cd] 	 222 [============================]
 DEBUG [3b4d13cd] 	
 DEBUG [3b4d13cd] 	 223 [============================]
 DEBUG [3b4d13cd] 	
 DEBUG [3b4d13cd] 	 224 [============================]
 DEBUG [3b4d13cd] 	
 DEBUG [3b4d13cd] 	 225 [============================]
 DEBUG [3b4d13cd] 	
 DEBUG [3b4d13cd] 	 226 [============================]
 DEBUG [3b4d13cd] 	
 DEBUG [3b4d13cd] 	 227 [============================]
```

This PR will make it look something like this:
```
 DEBUG [13de9473] 	 38690/77381 [=============>--------------]  49%
 DEBUG [13de9473] 	
 DEBUG [13de9473] 	 46428/77381 [================>-----------]  59%
 DEBUG [13de9473] 	
 DEBUG [13de9473] 	 54166/77381 [===================>--------]  69%
```